### PR TITLE
docs: add needed permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Amazon Device Farm File Deploy
 Uploads file (i.e. test package, app data, etc.) to device farm.
 
-This Step requires an Amazon Device Farm registration. To register an account, [click here](https://aws.amazon.com/device-farm/)
+This Step requires an Amazon Device Farm registration. To register an account, [click here](https://aws.amazon.com/device-farm/). 
+Please note that this user needs at least access to the DeviceFarm CreateUpload action, so `"devicefarm:CreateUpload"` should be in the user access permissions.
 
 ## How to use this Step
 


### PR DESCRIPTION
Hey there,

Thanks for this project, it really helped us for our integration tests!
I just figured out which permission the user needs so I added it to the docs.

I took this information from [this](http://docs.aws.amazon.com/devicefarm/latest/developerguide/permissions.html) and [this](http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_CreateUpload.html) AWS docs.

If you need further information, please let me know.