### PR TITLE
0.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
-## Changelog (Current version: 0.0.3)
+## Changelog (Current version: 0.0.4)
 
 -----------------
+### 0.0.4 (2017 Jun 21)
+
+* Export ARN of uploaded file
+* Update docs to try to make relationship to aws-device-farm-runner more clear & link setup instructions wiki
+* Update type tags again
 
 ### 0.0.3 (2017 May 10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 0.0.3 (2017 May 10)
 
 * Update docs with more info on required IAM permissions
+* Update type tags
 
 ### 0.0.2 (2016 Sept 22)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Amazon Device Farm File Deploy
-Uploads file (i.e. test package, app data, etc.) to device farm.
+Uploads file (i.e. test package, app data, etc.) to device farm. Intended to be used with the [aws-device-farm-runner](https://github.com/peartherapeutics/bitrise-aws-device-farm-runner) step.
 
-This Step requires an Amazon Device Farm registration. To register an account, [click here](https://aws.amazon.com/device-farm/). 
+This Step requires an Amazon Device Farm registration. [Please read the aws-device-farm-runner wiki for setup instructions](https://github.com/peartherapeutics/bitrise-aws-device-farm-runner/wiki).
+
 Please note that this user needs at least access to the DeviceFarm CreateUpload action, so `"devicefarm:CreateUpload"` should be in the user access permissions.
 
 ## How to use this Step

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,6 +24,17 @@ workflows:
         - upload_file_path: $DEVICE_FARM_UPLOAD_FILE_PATH
         - upload_type: $DEVICE_FARM_UPLOAD_FILE_TYPE
         - aws_region: $AWS_REGION
+    - script:
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            if [[ ! -z "$BITRISE_DEVICEFARM_UPLOAD_ARN" ]]; then
+                echo "Got upload ARN: $BITRISE_DEVICEFARM_UPLOAD_ARN"
+            else
+                echo "Did not get upload ARN" 1>&2
+                exit 1
+            fi
 
   # ----------------------------------------------------------------
   # --- workflow to Share this step into a Step Library

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,7 +6,10 @@ app:
   # define these in your .bitrise.secrets.yml
   - AWS_ACCESS_KEY: $AWS_ACCESS_KEY
   - AWS_SECRET_KEY: $AWS_SECRET_KEY
-  # - BUCKET_REGION: $BUCKET_REGION
+  - AWS_REGION: $AWS_REGION
+  - DEVICE_FARM_PROJECT: $DEVICE_FARM_PROJECT
+  - DEVICE_FARM_UPLOAD_FILE_PATH: $DEVICE_FARM_UPLOAD_FILE_PATH
+  - DEVICE_FARM_UPLOAD_FILE_TYPE: $DEVICE_FARM_UPLOAD_FILE_TYPE
 
 workflows:
   # ----------------------------------------------------------------
@@ -17,10 +20,10 @@ workflows:
         inputs:
         - access_key_id: $AWS_ACCESS_KEY
         - secret_access_key: $AWS_SECRET_KEY
-        - device_farm_project: ""
-        - upload_file_path: ""
-        - upload_type: "APPIUM_PYTHON_TEST_PACKAGE"
-        - aws_region: "us-west-2"
+        - device_farm_project: $DEVICE_FARM_PROJECT
+        - upload_file_path: $DEVICE_FARM_UPLOAD_FILE_PATH
+        - upload_type: $DEVICE_FARM_UPLOAD_FILE_TYPE
+        - aws_region: $AWS_REGION
 
   # ----------------------------------------------------------------
   # --- workflow to Share this step into a Step Library

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
     envs:
       - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
       - STEP_ID_IN_STEPLIB: aws-device-farm-file-deploy
-      - STEP_GIT_VERION_TAG_TO_SHARE: 0.0.3
+      - STEP_GIT_VERION_TAG_TO_SHARE: 0.0.4
       - STEP_GIT_CLONE_URL: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy.git
     description: |-
       If this is the first time you try to share a Step you should

--- a/step.sh
+++ b/step.sh
@@ -161,4 +161,6 @@ while [ ! "$upload_status" == 'SUCCEEDED' ]; do
     upload_status=$(get_upload_status "$upload_arn")
 done
 
+envman add --key BITRISE_DEVICEFARM_UPLOAD_ARN --value "$upload_arn"
+
 echo_details 'Upload successful!'

--- a/step.yml
+++ b/step.yml
@@ -1,9 +1,8 @@
 title: "Amazon Device Farm File Deploy"
 summary: "Amazon Device Farm File Deploy"
 description: |-
-  Uploads file (i.e. test package, app data, etc.) to device farm
-
-  This Step requires an Amazon Device Farm registration. To register an account, [click here](https://aws.amazon.com/device-farm/)
+  Uploads file (i.e. test package, app data, etc.) to device farm. Intended to be used with the [aws-device-farm-runner](https://github.com/peartherapeutics/bitrise-aws-device-farm-runner) step.
+  This step requires an Amazon Device Farm registration. [Please read the aws-device-farm-runner wiki for setup instructions](https://github.com/peartherapeutics/bitrise-aws-device-farm-runner/wiki).
 website: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy
 source_code_url: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy
 support_url: https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy/issues
@@ -14,6 +13,7 @@ host_os_tags:
 project_type_tags: []
 type_tags:
 - test
+- deploy
 is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
@@ -30,13 +30,13 @@ inputs:
     opts:
       title: "AWS Access Key"
       summary: ""
-      description: ""
+      description: "Access key for your AWS/IAM user. Define this as a secret environment variable in your workflow."
       is_required: true
   - secret_access_key: "$AWS_SECRET_KEY"
     opts:
       title: "AWS Secret Key"
       summary: ""
-      description: ""
+      description: "Secret key for your AWS/IAM user. Define this as a secret environment variable in your workflow."
       is_required: true
   - aws_region: "$AWS_REGION"
     opts:
@@ -49,18 +49,18 @@ inputs:
     opts:
       title: "Device Farm Project ARN"
       summary: ""
-      description: "Project ARNs can be obtained using the AWS CLI 'devicefarm list-projects' command."
+      description: "Project ARNs can be obtained using the [AWS CLI](https://aws.amazon.com/cli/) `devicefarm list-projects` command."
       is_required: true
   - upload_file_path: ""
     opts:
       title: "Upload File Path"
       summary: ""
-      description: "Path of file to upload. If this is a test package, aws-device-farm-runner can be configured to use the latest package with this name."
+      description: "Path of file to upload. If this is a test package, [aws-device-farm-runner](https://github.com/peartherapeutics/bitrise-aws-device-farm-runner) can be configured to use the latest package with this name."
       is_required: true
   - upload_type: ""
     opts:
       title: "Upload Type"
       summary: ""
-      description: "ex. APPIUM_PYTHON_TEST_PACKAGE. See http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_Upload.html#devicefarm-Type-Upload-type"
+      description: "ex. `APPIUM_PYTHON_TEST_PACKAGE`. See [Upload.type documentation](http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_Upload.html#devicefarm-Type-Upload-type)."
       is_required: true
 outputs: []

--- a/step.yml
+++ b/step.yml
@@ -63,4 +63,9 @@ inputs:
       summary: ""
       description: "ex. `APPIUM_PYTHON_TEST_PACKAGE`. See [Upload.type documentation](http://docs.aws.amazon.com/devicefarm/latest/APIReference/API_Upload.html#devicefarm-Type-Upload-type)."
       is_required: true
-outputs: []
+outputs:
+  - BITRISE_DEVICEFARM_UPLOAD_ARN:
+    opts:
+      title: Upload ARN
+      description: |-
+        ARN identifier of successfully uploaded file


### PR DESCRIPTION
- update changelog and bump version
 - export ARN of successfully uploaded file.
 - allow passing of all inputs via .bitrise.secrets.yml
 - improve docs

Closes https://github.com/peartherapeutics/bitrise-aws-device-farm-file-deploy/issues/9