### PR TITLE
Fix sleep command

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -154,7 +154,7 @@ while [ ! "$upload_status" == 'SUCCEEDED' ]; do
     fi
 
     echo_details "Upload not yet processed; waiting. (Status=$upload_status)"
-    sleep 10s
+    sleep 10
     upload_status=$(get_upload_status "$upload_arn")
 done
 


### PR DESCRIPTION
Seems that the GNU style sleep command is not supported by the latest
macOS versions. The default suffix is 'S' for seconds so this should be a backward-compatible fix.

Fixes #22